### PR TITLE
Don't trigger autosave when changing focus to a list view

### DIFF
--- a/lib/autosave.coffee
+++ b/lib/autosave.coffee
@@ -6,6 +6,10 @@ module.exports =
 
   activate: ->
     atom.workspaceView.on 'focusout', ".editor:not(.mini)", (event) =>
+      # Don't autosave if the focus change was towards a select list.
+      # Select lists will be opened by packages like autosuggest.
+      if $(event.relatedTarget).closest(".select-list").length
+        return
       editor = $(event.target).closest('.editor').view()?.getModel()
       @autosave(editor)
 


### PR DESCRIPTION
This should fix a couple of issues, including #3 and saschagehlich/autocomplete-plus#16.
