### PR TITLE
Don’t autosave when the editor contains the focused element on focusout

### DIFF
--- a/lib/autosave.coffee
+++ b/lib/autosave.coffee
@@ -9,8 +9,11 @@ module.exports =
     $(window).preempt 'beforeunload', => @autosaveAll()
 
     atom.workspaceView.on 'focusout', ".editor:not(.mini)", (event) =>
-      editor = $(event.target).closest('.editor').view()?.getModel()
-      @autosave(editor)
+      if editorView = $(event.target).closest('.editor').view()
+        # If focusing an element *contained* by the editor, don't autosave
+        return if editorView.element.contains(event.relatedTarget)
+        editor = editorView.getModel()
+        @autosave(editor)
 
     atom.workspaceView.on 'pane:before-item-destroyed', (event, paneItem) =>
       @autosave(paneItem)

--- a/spec/autosave-spec.coffee
+++ b/spec/autosave-spec.coffee
@@ -50,6 +50,13 @@ describe "Autosave", ->
         $('body').focus()
         expect(initialActiveItem.save).toHaveBeenCalled()
 
+      it "suppresses autosave if the focused element is contained by the editor, such as occurs when opening the autocomplete menu", ->
+        atom.config.set('autosave.enabled', true)
+        focusStealer = $('<div tabindex=-1></div>')
+        atom.workspaceView.getActiveView().append(focusStealer)
+        focusStealer.focus()
+        expect(initialActiveItem.save).not.toHaveBeenCalled()
+
     describe "when a new pane is created", ->
       it "saves the item if autosave is enabled and the item has a uri", ->
         leftPane = atom.workspaceView.getActivePaneView()


### PR DESCRIPTION
This prevents autosave when things like the autocomplete menu are opened.

I intend to merge this in place of #15 because it's more general, but thanks so much to @lucas-clemente for the inspiration of using `event.relatedTarget`.

Fixes #3
Fixes atom/autocomplete#46
Fixes saschagehlich/autocomplete-plus#16
Closes #15
