### PR TITLE
adding setting for save on focus

### DIFF
--- a/lib/autosave.coffee
+++ b/lib/autosave.coffee
@@ -5,6 +5,9 @@ module.exports =
     enabled:
       type: 'boolean'
       default: false
+    saveOnFocus:
+      type: 'boolean'
+      default: false
 
   subscriptions: null
 
@@ -17,6 +20,8 @@ module.exports =
     @subscriptions.add new Disposable -> window.removeEventListener('beforeunload', handleBeforeUnload, true)
 
     handleBlur = (event) =>
+      return unless atom.config.get('autosave.saveOnFocus')
+
       if event.target is window
         @autosaveAllPaneItems()
       else if event.target.matches('atom-text-editor:not([mini])') and not event.target.contains(event.relatedTarget)

--- a/lib/autosave.coffee
+++ b/lib/autosave.coffee
@@ -5,7 +5,7 @@ module.exports =
     enabled:
       type: 'boolean'
       default: false
-    saveOnFocus:
+    enableSaveOnFocusChange:
       type: 'boolean'
       default: false
 
@@ -20,7 +20,7 @@ module.exports =
     @subscriptions.add new Disposable -> window.removeEventListener('beforeunload', handleBeforeUnload, true)
 
     handleBlur = (event) =>
-      return unless atom.config.get('autosave.saveOnFocus')
+      return unless atom.config.get('autosave.enableSaveOnFocusChange')
 
       if event.target is window
         @autosaveAllPaneItems()

--- a/spec/autosave-spec.coffee
+++ b/spec/autosave-spec.coffee
@@ -29,7 +29,7 @@ describe "Autosave", ->
   describe "when the item is not modified", ->
     it "does not autosave the item", ->
       atom.config.set('autosave.enabled', true)
-      atom.config.set('autosave.saveOnFocus', true)
+      atom.config.set('autosave.enableSaveOnFocusChange', true)
       atom.workspace.getActivePane().splitRight(items: [otherItem1])
       expect(initialActiveItem.save).not.toHaveBeenCalled()
 
@@ -44,11 +44,11 @@ describe "Autosave", ->
 
         workspaceElement.focus()
         atom.config.set('autosave.enabled', true)
-        atom.config.set('autosave.saveOnFocus', true)
+        atom.config.set('autosave.enableSaveOnFocusChange', true)
         document.body.focus()
         expect(initialActiveItem.save).toHaveBeenCalled()
 
-      it "suppresses autosave if saveOnFocus is not enabled", ->
+      it "suppresses autosave if enableSaveOnFocusChange is not enabled", ->
         document.body.focus()
         expect(initialActiveItem.save).not.toHaveBeenCalled()
 
@@ -59,7 +59,7 @@ describe "Autosave", ->
 
       it "suppresses autosave if the focused element is contained by the editor, such as occurs when opening the autocomplete menu", ->
         atom.config.set('autosave.enabled', true)
-        atom.config.set('autosave.saveOnFocus', true)
+        atom.config.set('autosave.enableSaveOnFocusChange', true)
         focusStealer = document.createElement('div')
         focusStealer.setAttribute('tabindex', -1)
 
@@ -78,7 +78,7 @@ describe "Autosave", ->
         leftPane.activate()
 
         atom.config.set('autosave.enabled', true)
-        atom.config.set('autosave.saveOnFocus', true)
+        atom.config.set('autosave.enableSaveOnFocusChange', true)
         leftPane.splitRight()
         expect(initialActiveItem.save).toHaveBeenCalled()
 
@@ -94,7 +94,7 @@ describe "Autosave", ->
 
           otherItem2.setText("I am also modified")
           atom.config.set("autosave.enabled", true)
-          atom.config.set('autosave.saveOnFocus', true)
+          atom.config.set('autosave.enableSaveOnFocusChange', true)
           leftPane = rightPane.splitLeft(items: [otherItem2])
           expect(otherItem2).toBe atom.workspace.getActivePaneItem()
           leftPane.destroyItem(otherItem2)
@@ -110,7 +110,7 @@ describe "Autosave", ->
 
           otherItem2.setText("I am also modified")
           atom.config.set("autosave.enabled", true)
-          atom.config.set('autosave.saveOnFocus', true)
+          atom.config.set('autosave.enableSaveOnFocusChange', true)
           leftPane = rightPane.splitLeft(items: [otherItem2])
           rightPane.focus()
           expect(otherItem2).not.toBe atom.workspace.getActivePaneItem()
@@ -129,14 +129,14 @@ describe "Autosave", ->
           expect(pathLessItem.getURI()).toBeFalsy()
 
           atom.config.set('autosave.enabled', true)
-          atom.config.set('autosave.saveOnFocus', true)
+          atom.config.set('autosave.enableSaveOnFocusChange', true)
           atom.workspace.getActivePane().destroyItem(pathLessItem)
           expect(pathLessItem.save).not.toHaveBeenCalled()
 
   describe "when the window is blurred", ->
     it "saves all items", ->
       atom.config.set('autosave.enabled', true)
-      atom.config.set('autosave.saveOnFocus', true)
+      atom.config.set('autosave.enableSaveOnFocusChange', true)
 
       leftPane = atom.workspace.getActivePane()
       rightPane = leftPane.splitRight(items: [otherItem1])

--- a/spec/autosave-spec.coffee
+++ b/spec/autosave-spec.coffee
@@ -29,6 +29,7 @@ describe "Autosave", ->
   describe "when the item is not modified", ->
     it "does not autosave the item", ->
       atom.config.set('autosave.enabled', true)
+      atom.config.set('autosave.saveOnFocus', true)
       atom.workspace.getActivePane().splitRight(items: [otherItem1])
       expect(initialActiveItem.save).not.toHaveBeenCalled()
 
@@ -43,11 +44,22 @@ describe "Autosave", ->
 
         workspaceElement.focus()
         atom.config.set('autosave.enabled', true)
+        atom.config.set('autosave.saveOnFocus', true)
         document.body.focus()
         expect(initialActiveItem.save).toHaveBeenCalled()
 
+      it "suppresses autosave if saveOnFocus is not enabled", ->
+        document.body.focus()
+        expect(initialActiveItem.save).not.toHaveBeenCalled()
+
+        workspaceElement.focus()
+        atom.config.set('autosave.enabled', true)
+        document.body.focus()
+        expect(initialActiveItem.save).not.toHaveBeenCalled()
+
       it "suppresses autosave if the focused element is contained by the editor, such as occurs when opening the autocomplete menu", ->
         atom.config.set('autosave.enabled', true)
+        atom.config.set('autosave.saveOnFocus', true)
         focusStealer = document.createElement('div')
         focusStealer.setAttribute('tabindex', -1)
 
@@ -66,6 +78,7 @@ describe "Autosave", ->
         leftPane.activate()
 
         atom.config.set('autosave.enabled', true)
+        atom.config.set('autosave.saveOnFocus', true)
         leftPane.splitRight()
         expect(initialActiveItem.save).toHaveBeenCalled()
 
@@ -81,6 +94,7 @@ describe "Autosave", ->
 
           otherItem2.setText("I am also modified")
           atom.config.set("autosave.enabled", true)
+          atom.config.set('autosave.saveOnFocus', true)
           leftPane = rightPane.splitLeft(items: [otherItem2])
           expect(otherItem2).toBe atom.workspace.getActivePaneItem()
           leftPane.destroyItem(otherItem2)
@@ -96,6 +110,7 @@ describe "Autosave", ->
 
           otherItem2.setText("I am also modified")
           atom.config.set("autosave.enabled", true)
+          atom.config.set('autosave.saveOnFocus', true)
           leftPane = rightPane.splitLeft(items: [otherItem2])
           rightPane.focus()
           expect(otherItem2).not.toBe atom.workspace.getActivePaneItem()
@@ -114,12 +129,14 @@ describe "Autosave", ->
           expect(pathLessItem.getURI()).toBeFalsy()
 
           atom.config.set('autosave.enabled', true)
+          atom.config.set('autosave.saveOnFocus', true)
           atom.workspace.getActivePane().destroyItem(pathLessItem)
           expect(pathLessItem.save).not.toHaveBeenCalled()
 
   describe "when the window is blurred", ->
     it "saves all items", ->
       atom.config.set('autosave.enabled', true)
+      atom.config.set('autosave.saveOnFocus', true)
 
       leftPane = atom.workspace.getActivePane()
       rightPane = leftPane.splitRight(items: [otherItem1])


### PR DESCRIPTION
I added a setting in Atom.io core-package autosave to toggle save on focus off while preserving the save on exit functionality. I wanted to add this to prevent crashing build suites such as gulp and broccoli.
