### PR TITLE
Save via Pane for error handling

### DIFF
--- a/lib/autosave.coffee
+++ b/lib/autosave.coffee
@@ -37,7 +37,11 @@ module.exports =
     return unless paneItem?.isModified?()
     return unless paneItem?.getPath?()? and fs.isFileSync(paneItem.getPath())
 
-    paneItem?.save?()
+    pane = atom.workspace.paneForItem(paneItem)
+    if pane?
+      pane.saveItem(paneItem)
+    else
+      paneItem?.save?()
 
   autosaveAllPaneItems: ->
     @autosavePaneItem(paneItem) for paneItem in atom.workspace.getPaneItems()

--- a/lib/autosave.coffee
+++ b/lib/autosave.coffee
@@ -41,7 +41,7 @@ module.exports =
     if pane?
       pane.saveItem(paneItem)
     else
-      paneItem?.save?()
+      paneItem.save?()
 
   autosaveAllPaneItems: ->
     @autosavePaneItem(paneItem) for paneItem in atom.workspace.getPaneItems()

--- a/spec/autosave-spec.coffee
+++ b/spec/autosave-spec.coffee
@@ -157,6 +157,6 @@ describe "Autosave", ->
     initialActiveItem.insertText('a')
 
     atom.config.set('autosave.enabled', true)
-    atom.workspace.destroyActivePaneItem()
+    expect(-> atom.workspace.destroyActivePaneItem()).not.toThrow()
 
     expect(initialActiveItem.save).toHaveBeenCalled()

--- a/spec/autosave-spec.coffee
+++ b/spec/autosave-spec.coffee
@@ -154,9 +154,13 @@ describe "Autosave", ->
     saveError.code = 'EACCES'
     saveError.path = initialActiveItem.getPath()
     initialActiveItem.save.andThrow(saveError)
+
+    errorCallback = jasmine.createSpy('errorCallback').andCallFake ({preventDefault}) -> preventDefault()
+    atom.onWillThrowError(errorCallback)
+
     initialActiveItem.insertText('a')
-
     atom.config.set('autosave.enabled', true)
-    expect(-> atom.workspace.destroyActivePaneItem()).not.toThrow()
 
+    expect(-> atom.workspace.destroyActivePaneItem()).not.toThrow()
     expect(initialActiveItem.save).toHaveBeenCalled()
+    expect(errorCallback.callCount).toBe 1

--- a/spec/autosave-spec.coffee
+++ b/spec/autosave-spec.coffee
@@ -148,3 +148,15 @@ describe "Autosave", ->
 
       expect(initialActiveItem.save).toHaveBeenCalled()
       expect(otherItem1.save).toHaveBeenCalled()
+
+  it "saves via the item's Pane so that write errors are handled via notifications", ->
+    saveError = new Error('Save failed')
+    saveError.code = 'EACCES'
+    saveError.path = initialActiveItem.getPath()
+    initialActiveItem.save.andThrow(saveError)
+    initialActiveItem.insertText('a')
+
+    atom.config.set('autosave.enabled', true)
+    atom.workspace.destroyActivePaneItem()
+
+    expect(initialActiveItem.save).toHaveBeenCalled()


### PR DESCRIPTION
`Pane::save` does all sorts of error handling to show helpful notifications about permission, filesystem issues, etc.

Use that instead of calling `save()` directly on the pane item so we get the same notification experience when autosave is enabled.

Closes #29
Closes #33
Closes #36
Closes #40