### PR TITLE
Fix autosave not working without shadow DOM

### DIFF
--- a/lib/autosave.coffee
+++ b/lib/autosave.coffee
@@ -15,8 +15,9 @@ module.exports =
     handleBlur = (event) =>
       if event.target is window
         @autosaveAllPaneItems()
-      else if event.target.matches('atom-text-editor:not([mini])') and not event.target.contains(event.relatedTarget)
-        @autosavePaneItem(event.target.getModel())
+      else if editorElement = event.target.closest('atom-text-editor:not(mini)')
+        unless event.target.matches('atom-text-editor:not(mini)') or editorElement.contains(event.relatedTarget)
+          @autosavePaneItem(editorElement.getModel())
 
     window.addEventListener('blur', handleBlur, true)
     @subscriptions.add new Disposable -> window.removeEventListener('blur', handleBlur, true)

--- a/lib/autosave.coffee
+++ b/lib/autosave.coffee
@@ -16,7 +16,7 @@ module.exports =
       if event.target is window
         @autosaveAllPaneItems()
       else if editorElement = event.target.closest('atom-text-editor:not(mini)')
-        unless event.target.matches('atom-text-editor:not(mini)') or editorElement.contains(event.relatedTarget)
+        unless editorElement.contains(event.relatedTarget) or (editorElement.lightDOM and editorElement is event.target)
           @autosavePaneItem(editorElement.getModel())
 
     window.addEventListener('blur', handleBlur, true)


### PR DESCRIPTION
When the editor element is blurred, the DOM will now dispatch an event indicating the hidden `<input>` element as its `target` and the newly focused element as its `relatedTarget`. This pull request fixes autosave to work correctly when shadow DOM is enabled.