### PR TITLE
Add setting for ignoring files

### DIFF
--- a/lib/autosave.coffee
+++ b/lib/autosave.coffee
@@ -28,10 +28,13 @@ module.exports =
     @subscriptions.dispose()
 
   autosavePaneItem: (paneItem) ->
+    ignorable = (file) -> new RegExp(file).test(paneItem.getPath())
+    filesToIgnore = atom.config.get('autosave.ignoreFiles')?.split(',') || []
     return unless atom.config.get('autosave.enabled')
     return unless paneItem?.getURI?()?
     return unless paneItem?.isModified?()
     return unless paneItem?.getPath?()? and fs.isFileSync(paneItem.getPath())
+    return if filesToIgnore.some(ignorable)
 
     pane = atom.workspace.paneForItem(paneItem)
     if pane?

--- a/package.json
+++ b/package.json
@@ -18,6 +18,12 @@
     "enabled": {
       "type": "boolean",
       "default": false
+    },
+    "ignoreFiles": {
+      "title": "Files to ignore",
+      "type": "string",
+      "description": "Files which should not be autosaved",
+      "default": null
     }
   }
 }

--- a/spec/autosave-spec.coffee
+++ b/spec/autosave-spec.coffee
@@ -140,6 +140,20 @@ describe "Autosave", ->
           atom.workspace.getActivePane().destroyItem(pathLessItem)
           expect(pathLessItem.save).not.toHaveBeenCalled()
 
+    describe "when the item is ignored in the settings", ->
+      it "does not save the item", ->
+        waitsForPromise ->
+          atom.workspace.open('sample.js')
+
+        runs ->
+          atom.config.set('autosave.enabled', true)
+          atom.config.set('autosave.ignoreFiles', 'sample.js')
+          file = atom.workspace.getActiveTextEditor()
+          file.insertText('text!')
+
+          window.dispatchEvent(new FocusEvent('blur'))
+          expect(file.save).not.toHaveBeenCalled()
+
   describe "when the window is blurred", ->
     it "saves all items", ->
       atom.config.set('autosave.enabled', true)


### PR DESCRIPTION
This is a user focused alternative to #45. This could probably be improved by using glob matching rather than regex for matching file paths