### PR TITLE
Autosave on pane item creation

### DIFF
--- a/lib/autosave.js
+++ b/lib/autosave.js
@@ -29,6 +29,7 @@ module.exports = {
     window.addEventListener('blur', handleBlur, true)
     this.subscriptions.add(new Disposable(() => window.removeEventListener('blur', handleBlur, true)))
 
+    this.subscriptions.add(atom.workspace.onDidAddPaneItem(({item}) => this.autosavePaneItem(item, true)))
     this.subscriptions.add(atom.workspace.onWillDestroyPaneItem(({item}) => this.autosavePaneItem(item)))
   },
 
@@ -36,14 +37,21 @@ module.exports = {
     this.subscriptions.dispose()
   },
 
-  autosavePaneItem (paneItem) {
+  autosavePaneItem (paneItem, create = false) {
     if (!atom.config.get('autosave.enabled')) return
     if (!paneItem) return
     if (typeof paneItem.getURI !== 'function' || !paneItem.getURI()) return
-    if (typeof paneItem.isModified !== 'function' || !paneItem.isModified()) return
+    if (!create && (typeof paneItem.isModified !== 'function' || !paneItem.isModified())) return
     if (typeof paneItem.getPath !== 'function' || !paneItem.getPath()) return
-    if (!fs.isFileSync(paneItem.getPath())) return
     if (!shouldSave(paneItem)) return
+
+    try {
+      const stats = fs.statSync(paneItem.getPath())
+      if (!stats.isFile()) return
+    } catch (e) {
+      if (e.code !== 'ENOENT') return
+      if (!create) return
+    }
 
     const pane = atom.workspace.paneForItem(paneItem)
     if (pane) {

--- a/spec/autosave-spec.js
+++ b/spec/autosave-spec.js
@@ -28,6 +28,14 @@ describe('Autosave', () => {
   })
 
   describe('when the item is not modified', () => {
+    it('autosaves newly added items', async () => {
+      atom.config.set('autosave.enabled', true)
+      spyOn(atom.workspace.getActivePane(), 'saveItem')
+      const newItem = await atom.workspace.open('notyet.coffee')
+
+      expect(atom.workspace.getActivePane().saveItem).toHaveBeenCalledWith(newItem)
+    })
+
     it('does not autosave the item', () => {
       atom.config.set('autosave.enabled', true)
       atom.workspace.getActivePane().splitRight({items: [otherItem1]})

--- a/spec/autosave-spec.js
+++ b/spec/autosave-spec.js
@@ -191,20 +191,18 @@ describe('Autosave', () => {
 
   describe('dontSaveIf service', () => {
     it("doesn't save a paneItem if a predicate function registered via the dontSaveIf service returns true", async () => {
+      atom.workspace.getActivePane().addItem(otherItem1)
       atom.config.set('autosave.enabled', true)
       const service = atom.packages.getActivePackage('autosave').mainModule.provideService()
       service.dontSaveIf(paneItem => paneItem === initialActiveItem)
 
-      const anotherPaneItem = await atom.workspace.open('sample.coffee')
-
-      spyOn(anotherPaneItem, 'save')
       initialActiveItem.setText('foo')
-      anotherPaneItem.setText('bar')
+      otherItem1.setText('bar')
 
       window.dispatchEvent(new FocusEvent('blur'))
 
       expect(initialActiveItem.save).not.toHaveBeenCalled()
-      expect(anotherPaneItem.save).toHaveBeenCalled()
+      expect(otherItem1.save).toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
Trigger an autosave when a new PaneItem is created. Allow it to create files that do not exist and skip the `isModified()` check.

This causes autosave to fire when Atom is first launching and bypass the `fs.stat` check that would otherwise prevent the new file from being created, addressing the first bit of #67 without regressing #35's work to address #9. 