### PR TITLE
Delay package deactivation until pending saves complete

### DIFF
--- a/lib/autosave.js
+++ b/lib/autosave.js
@@ -70,20 +70,14 @@ module.exports = {
       }
     }
 
-    try {
-      const pane = atom.workspace.paneForItem(paneItem)
-      let promise = Promise.resolve()
-      if (pane) {
-        promise = pane.saveItem(paneItem)
-      } else if (typeof paneItem.save === 'function') {
-        promise = paneItem.save()
-      }
-      return promise.then(saveComplete, saveComplete)
-    } catch (e) {
-      // A synchronous .save() call threw an error
-      saveComplete()
-      return Promise.reject(e)
+    const pane = atom.workspace.paneForItem(paneItem)
+    let promise = Promise.resolve()
+    if (pane) {
+      promise = pane.saveItem(paneItem)
+    } else if (typeof paneItem.save === 'function') {
+      promise = paneItem.save()
     }
+    return promise.then(saveComplete, saveComplete)
   },
 
   autosaveAllPaneItems () {

--- a/lib/autosave.js
+++ b/lib/autosave.js
@@ -4,8 +4,6 @@ const {dontSaveIf, shouldSave} = require('./controls')
 
 module.exports = {
   subscriptions: null,
-  pendingSaves: 0,
-  resolvePendingSaves: () => {},
 
   provideService () {
     return {dontSaveIf}
@@ -13,11 +11,6 @@ module.exports = {
 
   activate () {
     this.subscriptions = new CompositeDisposable()
-
-    const handleBeforeUnload = this.autosaveAllPaneItems.bind(this)
-
-    window.addEventListener('beforeunload', handleBeforeUnload, true)
-    this.subscriptions.add(new Disposable(function () { return window.removeEventListener('beforeunload', handleBeforeUnload, true) }))
 
     const handleBlur = event => {
       if (event.target === window) {
@@ -37,13 +30,7 @@ module.exports = {
 
   deactivate () {
     this.subscriptions.dispose()
-    return new Promise(resolve => {
-      if (this.pendingSaves === 0) {
-        resolve()
-      } else {
-        this.resolvePendingSaves = resolve
-      }
-    })
+    return this.autosaveAllPaneItems()
   },
 
   autosavePaneItem (paneItem, create = false) {
@@ -62,14 +49,6 @@ module.exports = {
       if (!create) return
     }
 
-    this.pendingSaves++
-    const saveComplete = () => {
-      this.pendingSaves--
-      if (this.pendingSaves === 0) {
-        this.resolvePendingSaves()
-      }
-    }
-
     const pane = atom.workspace.paneForItem(paneItem)
     let promise = Promise.resolve()
     if (pane) {
@@ -77,10 +56,12 @@ module.exports = {
     } else if (typeof paneItem.save === 'function') {
       promise = paneItem.save()
     }
-    return promise.then(saveComplete, saveComplete)
+    return promise
   },
 
   autosaveAllPaneItems () {
-    return atom.workspace.getPaneItems().map((paneItem) => this.autosavePaneItem(paneItem))
+    return Promise.all(
+      atom.workspace.getPaneItems().map((paneItem) => this.autosavePaneItem(paneItem))
+    )
   }
 }

--- a/lib/autosave.js
+++ b/lib/autosave.js
@@ -70,14 +70,20 @@ module.exports = {
       }
     }
 
-    const pane = atom.workspace.paneForItem(paneItem)
-    let promise = Promise.resolve()
-    if (pane) {
-      promise = pane.saveItem(paneItem)
-    } else if (typeof paneItem.save === 'function') {
-      promise = paneItem.save()
+    try {
+      const pane = atom.workspace.paneForItem(paneItem)
+      let promise = Promise.resolve()
+      if (pane) {
+        promise = pane.saveItem(paneItem)
+      } else if (typeof paneItem.save === 'function') {
+        promise = paneItem.save()
+      }
+      return promise.then(saveComplete, saveComplete)
+    } catch (e) {
+      // A synchronous .save() call threw an error
+      saveComplete()
+      return Promise.reject(e)
     }
-    return promise.then(saveComplete, saveComplete)
   },
 
   autosaveAllPaneItems () {

--- a/lib/autosave.js
+++ b/lib/autosave.js
@@ -4,6 +4,8 @@ const {dontSaveIf, shouldSave} = require('./controls')
 
 module.exports = {
   subscriptions: null,
+  pendingSaves: 0,
+  resolvePendingSaves: () => {},
 
   provideService () {
     return {dontSaveIf}
@@ -35,6 +37,13 @@ module.exports = {
 
   deactivate () {
     this.subscriptions.dispose()
+    return new Promise(resolve => {
+      if (this.pendingSaves === 0) {
+        resolve()
+      } else {
+        this.resolvePendingSaves = resolve
+      }
+    })
   },
 
   autosavePaneItem (paneItem, create = false) {
@@ -53,14 +62,22 @@ module.exports = {
       if (!create) return
     }
 
-    const pane = atom.workspace.paneForItem(paneItem)
-    if (pane) {
-      return pane.saveItem(paneItem)
-    } else if (typeof paneItem.save === 'function') {
-      return paneItem.save()
-    } else {
-      return Promise.resolve()
+    this.pendingSaves++
+    const saveComplete = () => {
+      this.pendingSaves--
+      if (this.pendingSaves === 0) {
+        this.resolvePendingSaves()
+      }
     }
+
+    const pane = atom.workspace.paneForItem(paneItem)
+    let promise = Promise.resolve()
+    if (pane) {
+      promise = pane.saveItem(paneItem)
+    } else if (typeof paneItem.save === 'function') {
+      promise = paneItem.save()
+    }
+    return promise.then(saveComplete, saveComplete)
   },
 
   autosaveAllPaneItems () {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
       "beforeEach",
       "jasmine",
       "waitsForPromise",
+      "waitsFor",
       "runs",
       "spyOn",
       "FocusEvent",

--- a/spec/autosave-spec.js
+++ b/spec/autosave-spec.js
@@ -22,15 +22,15 @@ describe('Autosave', () => {
 
     otherItem2 = otherItem1.copy()
 
-    spyOn(initialActiveItem, 'save')
-    spyOn(otherItem1, 'save')
-    spyOn(otherItem2, 'save')
+    spyOn(initialActiveItem, 'save').andCallFake(() => Promise.resolve())
+    spyOn(otherItem1, 'save').andCallFake(() => Promise.resolve())
+    spyOn(otherItem2, 'save').andCallFake(() => Promise.resolve())
   })
 
   describe('when the item is not modified', () => {
     it('autosaves newly added items', async () => {
       atom.config.set('autosave.enabled', true)
-      spyOn(atom.workspace.getActivePane(), 'saveItem')
+      spyOn(atom.workspace.getActivePane(), 'saveItem').andCallFake(() => Promise.resolve())
       const newItem = await atom.workspace.open('notyet.coffee')
 
       expect(atom.workspace.getActivePane().saveItem).toHaveBeenCalledWith(newItem)

--- a/spec/autosave-spec.js
+++ b/spec/autosave-spec.js
@@ -197,7 +197,7 @@ describe('Autosave', () => {
       })
 
       const deactivatePromise = atom.packages.deactivatePackage('autosave')
-      if (typeof deactivatePromise.then !== 'function') {
+      if (!deactivatePromise.then || typeof deactivatePromise.then !== 'function') {
         // Atom does not support asynchronous package deactivation.
         return
       }

--- a/spec/autosave-spec.js
+++ b/spec/autosave-spec.js
@@ -230,6 +230,8 @@ describe('Autosave', () => {
     saveError.path = initialActiveItem.getPath()
     initialActiveItem.save.andCallFake(() => Promise.reject(saveError))
 
+    const errorCallback = jasmine.createSpy('errorCallback').andCallFake(({preventDefault}) => preventDefault())
+    atom.onWillThrowError(errorCallback)
     spyOn(atom.notifications, 'addWarning')
 
     initialActiveItem.insertText('a')
@@ -237,7 +239,7 @@ describe('Autosave', () => {
 
     await atom.workspace.destroyActivePaneItem()
     expect(initialActiveItem.save).toHaveBeenCalled()
-    expect(atom.notifications.addWarning).toHaveBeenCalled()
+    expect(atom.notifications.addWarning.callCount > 0 || errorCallback.callCount > 0).toBe(true)
   })
 
   describe('dontSaveIf service', () => {

--- a/spec/autosave-spec.js
+++ b/spec/autosave-spec.js
@@ -197,7 +197,7 @@ describe('Autosave', () => {
       })
 
       const deactivatePromise = atom.packages.deactivatePackage('autosave')
-      if (!deactivatePromise.then || typeof deactivatePromise.then !== 'function') {
+      if (!deactivatePromise || !deactivatePromise.then || typeof deactivatePromise.then !== 'function') {
         // Atom does not support asynchronous package deactivation.
         return
       }

--- a/spec/autosave-spec.js
+++ b/spec/autosave-spec.js
@@ -223,17 +223,16 @@ describe('Autosave', () => {
     const saveError = new Error('Save failed')
     saveError.code = 'EACCES'
     saveError.path = initialActiveItem.getPath()
-    initialActiveItem.save.andThrow(saveError)
+    initialActiveItem.save.andCallFake(() => Promise.reject(saveError))
 
-    const errorCallback = jasmine.createSpy('errorCallback').andCallFake(({preventDefault}) => preventDefault())
-    atom.onWillThrowError(errorCallback)
+    spyOn(atom.notifications, 'addWarning')
 
     initialActiveItem.insertText('a')
     atom.config.set('autosave.enabled', true)
 
     await atom.workspace.destroyActivePaneItem()
     expect(initialActiveItem.save).toHaveBeenCalled()
-    expect(errorCallback.callCount).toBe(1)
+    expect(atom.notifications.addWarning).toHaveBeenCalled()
   })
 
   describe('dontSaveIf service', () => {

--- a/spec/autosave-spec.js
+++ b/spec/autosave-spec.js
@@ -172,8 +172,8 @@ describe('Autosave', () => {
     })
   })
 
-  describe('when the window is unloaded', () => {
-    it('saves all items and waits for saves to complete before deactivating', () => {
+  describe('when the package is deactivated', () => {
+    it('saves all items and waits for saves to complete', () => {
       atom.config.set('autosave.enabled', true)
 
       const leftPane = atom.workspace.getActivePane()
@@ -195,12 +195,6 @@ describe('Autosave', () => {
           resolveOther = resolve
         })
       })
-
-      // Triggering the beforeunload event tears down too much.
-      atom.packages.getActivePackage('autosave').mainModule.autosaveAllPaneItems()
-
-      expect(initialActiveItem.save).toHaveBeenCalled()
-      expect(otherItem1.save).toHaveBeenCalled()
 
       const deactivatePromise = atom.packages.deactivatePackage('autosave')
       if (typeof deactivatePromise.then !== 'function') {

--- a/spec/autosave-spec.js
+++ b/spec/autosave-spec.js
@@ -222,7 +222,7 @@ describe('Autosave', () => {
     const saveError = new Error('Save failed')
     saveError.code = 'EACCES'
     saveError.path = initialActiveItem.getPath()
-    initialActiveItem.save.andCallFake(() => Promise.reject(saveError))
+    initialActiveItem.save.andThrow(saveError)
 
     const errorCallback = jasmine.createSpy('errorCallback').andCallFake(({preventDefault}) => preventDefault())
     atom.onWillThrowError(errorCallback)

--- a/spec/autosave-spec.js
+++ b/spec/autosave-spec.js
@@ -202,7 +202,12 @@ describe('Autosave', () => {
       expect(initialActiveItem.save).toHaveBeenCalled()
       expect(otherItem1.save).toHaveBeenCalled()
 
-      atom.packages.deactivatePackage('autosave').then(() => {
+      const deactivatePromise = atom.packages.deactivatePackage('autosave')
+      if (typeof deactivatePromise.then !== 'function') {
+        // Atom does not support asynchronous package deactivation.
+        return
+      }
+      deactivatePromise.then(() => {
         deactivated = true
       })
 


### PR DESCRIPTION
Return a Promise from `.deactivate()` that resolves when all saves currently in progress complete, successfully or otherwise.

Depends on atom/atom#15740 and atom/atom#15554 for async deactivate support in core, so this won't work until Atom >= v1.21.0-beta0, and I'll need to make sure the specs are still green on stable and beta somehow :eyes:

Fixes #67.