### PR TITLE
update instructions for enabling autosave

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 
 Autosaves editor when they lose focus, are destroyed, or when the window is closed.
 
-This package is disabled by default and can be enabled via the
-`autosave.enabled` config setting or from the Autosave section of the Settings view (OS X: <kbd>cmd-,</kbd>, Windows & Linux: <kbd>Ctrl-,</kbd>).
+This package is disabled by default and can be enabled via the `autosave.enabled` config
+setting or by checking *Enabled* in the settings for the *autosave* package in the
+Settings view.
 
 ## Service API
 The service exposes an object with a function `dontSaveIf`, which accepts a callback.


### PR DESCRIPTION
It appears autosave is no longer on the global settings pages. I can't find it on Core or Editor in the Settings view. I needed to go to the package settings in order to enable it.

### Description of the Change

This changes the instructions in the README so that rather than suggesting going to the global settings view, to go to the settings for the *autosave* package.

### Alternate Designs

Perhaps the whole package could be disabled by default and enabling the package would enable the autosave behavior. Then the setting could be removed.

### Benefits

It could save half a minute if someone comes to the package wanting to enable it.

### Possible Drawbacks

This doesn't have the cool <kbd>kbd</kbd> markup that I discovered while looking at it, since it provides high level instructions.

### Applicable Issues

N/A