### PR TITLE
Removed the check for the editor not containing the related target 

### DIFF
--- a/lib/autosave.js
+++ b/lib/autosave.js
@@ -15,8 +15,7 @@ module.exports = {
     const handleBlur = event => {
       if (event.target === window) {
         this.autosaveAllPaneItems()
-
-      } else if (event.target.matches('atom-text-editor:not(mini)')) {    
+      } else if (event.target.matches('atom-text-editor:not(mini)')) {
         return this.autosavePaneItem(event.target.getModel())
       }
     }

--- a/lib/autosave.js
+++ b/lib/autosave.js
@@ -16,7 +16,7 @@ module.exports = {
       if (event.target === window) {
         this.autosaveAllPaneItems()
 
-      } else if (event.target.matches('atom-text-editor:not(mini)') {
+      } else if (event.target.matches('atom-text-editor:not(mini)')) {    
         return this.autosavePaneItem(event.target.getModel())
       }
     }

--- a/lib/autosave.js
+++ b/lib/autosave.js
@@ -15,8 +15,8 @@ module.exports = {
     const handleBlur = event => {
       if (event.target === window) {
         this.autosaveAllPaneItems()
-      // TODO: We can remove the check for the editor not containing the related target once 1.18 reaches stable
-      } else if (event.target.matches('atom-text-editor:not(mini)') && !event.target.contains(event.relatedTarget)) {
+
+      } else if (event.target.matches('atom-text-editor:not(mini)') {
         return this.autosavePaneItem(event.target.getModel())
       }
     }


### PR DESCRIPTION
since 1.18 has become stable.

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

I removed the temp check and the comment. 

### Alternate Designs

N/A

### Benefits

Cleaner slightly faster code

### Possible Drawbacks

N/A

### Applicable Issues

N/A
